### PR TITLE
make pages public so they can be re-used

### DIFF
--- a/voce-settings-api.php
+++ b/voce-settings-api.php
@@ -12,7 +12,7 @@ require_once(dirname(__FILE__).'/sanitize-callbacks.php');
 class Voce_Settings_API {
 	private static $instance;
 
-	private $settings_pages;
+	public $settings_pages;
 	
 	CONST VERSION = 0.2;
 


### PR DESCRIPTION
@prettyboymp 

If we keep this public I can add additional groups and settings in other files

example:

first-file.php

```
Voce_Settings_API::GetInstance()
  ->add_page('Global Site Settings', 'Global Site Settings', 'global-site-settings', '', '')
  ->add_group('Connect Services', 'connect-services')
  ->add_setting('Facebook Account Link', 'facebook_link')
```

another_module_file.php

```
Voce_Settings_API::GetInstance()
  ->settings_pages['global-site-settings']
  ->add_group( 'Twitter Authentication', 'twitter-auth' )
  ->add_setting( 'Consumer Key', 'twitter_consumer_key' )

```

You could also write a getter method for the setting page if you didn't want to make this public
